### PR TITLE
docs: add SDD specification documents

### DIFF
--- a/docs/spec/allocator.md
+++ b/docs/spec/allocator.md
@@ -1,0 +1,70 @@
+# Allocator Spec
+
+## Overview
+
+The Allocator module provides a unified memory allocation interface. The
+allocation backend is selected at compile time.
+
+## Interfaces
+
+### uvhttp_alloc
+- **Signature**: `void* uvhttp_alloc(size_t size)`
+- **Purpose**: Allocate memory
+- **Preconditions**: `size` > 0
+- **Returns**: Pointer to allocated memory, or NULL on failure.
+- **Thread safety**: Depends on backend (system allocator is thread-safe).
+
+### uvhttp_free
+- **Signature**: `void uvhttp_free(void* ptr)`
+- **Purpose**: Free allocated memory
+- **Preconditions**: `ptr` must be from `uvhttp_alloc`, `uvhttp_calloc`, or `uvhttp_realloc`. Can be NULL (no-op).
+- **Thread safety**: Depends on backend.
+
+### uvhttp_realloc
+- **Signature**: `void* uvhttp_realloc(void* ptr, size_t size)`
+- **Purpose**: Reallocate memory
+- **Preconditions**: `ptr` must be from a previous allocation. Can be NULL (equivalent to alloc).
+- **Returns**: Pointer to reallocated memory, or NULL on failure.
+- **Thread safety**: Depends on backend.
+
+### uvhttp_calloc
+- **Signature**: `void* uvhttp_calloc(size_t nmemb, size_t size)`
+- **Purpose**: Allocate and zero-initialize memory
+- **Preconditions**: `nmemb * size` > 0
+- **Returns**: Pointer to zero-initialized memory, or NULL on failure.
+- **Thread safety**: Depends on backend.
+
+### uvhttp_allocator_name
+- **Signature**: `const char* uvhttp_allocator_name(void)`
+- **Purpose**: Get the name of the current allocator backend
+- **Returns**: "system", "mimalloc", or "custom".
+- **Thread safety**: Thread-safe.
+
+## Backends
+
+| Type | Value | Description |
+|------|-------|-------------|
+| System | 0 | Standard `malloc`/`free` |
+| mimalloc | 1 | Microsoft mimalloc |
+| Custom | 2 | User-provided allocator |
+
+## Behavior Rules
+
+1. **Rule 1**: Never mix allocators. Memory allocated with `uvhttp_alloc` must be freed with `uvhttp_free`.
+
+2. **Rule 2**: Always check allocation results. NULL means out of memory.
+
+3. **Rule 3**: Every allocation must have a matching free. No leaks.
+
+4. **Rule 4**: NULL can be passed to `uvhttp_free` safely (no-op).
+
+## Test Requirements
+
+- Basic allocation and free
+- Zero-size allocation
+- Large allocation
+- Reallocation
+- Calloc zero-initialization
+- NULL free (no-op)
+- Allocator name retrieval
+- No leaks under ASan

--- a/docs/spec/build-system.md
+++ b/docs/spec/build-system.md
@@ -1,0 +1,113 @@
+# Build System Spec
+
+## Overview
+
+UVHTTP uses CMake as its build system. This spec defines the build
+configuration, C standard, compiler flags, and CI build matrix.
+
+## C Standard
+
+- **Standard**: C99 (`CMAKE_C_STANDARD 99`)
+- **Enforcement**: `CMAKE_C_STANDARD_REQUIRED ON`
+- **Compiler support**: GCC 4.8+, Clang 3.4+
+
+## Build Types
+
+| Type | CMake Preset | Flags | Use Case |
+|------|-------------|-------|----------|
+| Debug | `-DCMAKE_BUILD_TYPE=Debug` | `-g -O0` | Development, ASan |
+| Release | `-DCMAKE_BUILD_TYPE=Release` | `-O2 -DNDEBUG` | Production, benchmarks |
+| Coverage | `-DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON` | `--coverage` | Test coverage analysis |
+| ASan | `-DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON` | `-fsanitize=address` | Memory safety |
+| UBSan | `-DCMAKE_BUILD_TYPE=Debug -DENABLE_UBSAN=ON` | `-fsanitize=undefined` | UB detection |
+| Benchmark | `-DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARKS=ON` | `-O2 -DNDEBUG` | Performance testing |
+
+## Compiler Flags (All Builds)
+
+```cmake
+-Wall -Wextra -Wformat=2 -Wformat-security
+-fstack-protector-strong
+-fno-common
+-Werror
+-Werror=implicit-function-declaration
+-Werror=format-security
+-Werror=return-type
+-D_FORTIFY_SOURCE=2
+```
+
+## Linker Flags (All Builds)
+
+```cmake
+-Wl,-z,relro -Wl,-z,now
+```
+
+## Feature Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `BUILD_WITH_WEBSOCKET` | ON | WebSocket support |
+| `BUILD_WITH_HTTPS` | ON | TLS support (mbedtls) |
+| `BUILD_WITH_MIMALLOC` | OFF | Use mimalloc allocator |
+| `BUILD_WITH_COMPRESSION` | OFF | Compression support (zlib) |
+| `BUILD_TESTING` | ON | Build test suite |
+| `BUILD_EXAMPLES` | OFF | Build example programs |
+| `BUILD_BENCHMARKS` | OFF | Build benchmark server |
+| `UVHTTP_FEATURE_STATIC_FILES` | ON | Static file serving |
+| `UVHTTP_FEATURE_RATE_LIMIT` | ON | Rate limiting |
+| `UVHTTP_FEATURE_LRU_CACHE` | ON | LRU cache |
+| `UVHTTP_FEATURE_MIDDLEWARE` | ON | Middleware support |
+| `UVHTTP_ALLOCATOR_TYPE` | 0 | 0=system, 1=mimalloc, 2=custom |
+
+## Allocator
+
+The allocator is selected at compile time via `UVHTTP_ALLOCATOR_TYPE`:
+
+- **0**: System allocator (`malloc`/`free`)
+- **1**: mimalloc (when `BUILD_WITH_MIMALLOC=ON`)
+- **2**: Custom allocator (user-provided)
+
+## CI Build Matrix
+
+| Workflow | Trigger | Scope |
+|----------|---------|-------|
+| `ci-pr.yml` | Every PR | Build, unit tests, ASan gate, code quality |
+| `ci-nightly.yml` | Nightly | Full build matrix, coverage, stress, ASan+UBSan |
+| `ci-fuzz.yml` | Nightly | libFuzzer + ASan (60s per target) |
+| `deploy-docs.yml` | Push to main | Build and deploy VitePress docs |
+
+## Makefile Targets
+
+| Target | Description |
+|--------|-------------|
+| `make -f GNUmakefile build` | Debug build |
+| `make -f GNUmakefile build-release` | Release build |
+| `make -f GNUmakefile test` | Run tests |
+| `make -f GNUmakefile verify-memory-safety` | ASan + UBSan gate |
+| `make -f GNUmakefile docs` | Build all documentation |
+| `make -f GNUmakefile docs-clean` | Clean generated docs |
+| `make -f GNUmakefile bench` | Benchmark build |
+
+## Test Registration
+
+- Unit tests: 91 test files, discovered via `file(GLOB_RECURSE ...)`
+- Each test file becomes its own CTest test
+- Integration tests: standalone server programs (not registered with CTest)
+- Fuzz tests: libFuzzer harness (not registered with CTest)
+
+## Directory Structure
+
+```
+uvhttp/
+├── src/           # Source files (17 .c files)
+├── include/       # Public headers (28 .h files)
+├── test/          # Test files
+│   ├── unit/      # Google Test unit tests
+│   ├── integration/  # Integration test servers
+│   ├── mock/      # libuv mock library
+│   └── fuzz/      # libFuzzer harnesses
+├── deps/          # Vendored dependencies (git submodules)
+├── examples/      # Example programs
+├── benchmark/     # Benchmark server
+├── docs/          # Documentation (VitePress)
+└── scripts/       # Build and utility scripts
+```

--- a/docs/spec/config-api.md
+++ b/docs/spec/config-api.md
@@ -1,0 +1,82 @@
+# Config API Spec
+
+## Overview
+
+The Config module provides server configuration options. Configuration is
+set at the server level and can be shared across multiple server instances.
+
+## Interfaces
+
+### uvhttp_config_new
+- **Signature**: `uvhttp_error_t uvhttp_config_new(uvhttp_config_t** config)`
+- **Purpose**: Create a new config object with default values
+- **Preconditions**: `config` must be non-NULL.
+- **Postconditions**: On success, `*config` points to a config with all default values.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: config is NULL
+  - `UVHTTP_ERROR_OUT_OF_MEMORY`: allocation failure
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_config_free
+- **Signature**: `void uvhttp_config_free(uvhttp_config_t* config)`
+- **Purpose**: Free a config object
+- **Preconditions**: `config` can be NULL (no-op).
+- **Postconditions**: All memory is freed.
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_config_set_defaults
+- **Signature**: `void uvhttp_config_set_defaults(uvhttp_config_t* config)`
+- **Purpose**: Reset config to default values
+- **Preconditions**: `config` must be valid.
+- **Postconditions**: All config fields are set to their default values.
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_config_validate
+- **Signature**: `int uvhttp_config_validate(const uvhttp_config_t* config)`
+- **Purpose**: Validate config values against min/max bounds
+- **Preconditions**: `config` must be valid.
+- **Returns**: 0 if valid, non-zero (error code) if invalid.
+- **Thread safety**: Thread-safe for reads.
+
+### uvhttp_config_get_current / uvhttp_config_set_current
+- **Signature**: `uvhttp_config_t* uvhttp_config_get_current(uvhttp_context_t* context)` / `void uvhttp_config_set_current(uvhttp_context_t* context, uvhttp_config_t* config)`
+- **Purpose**: Get/set the current config on a context
+- **Preconditions**: `context` must be valid.
+- **Thread safety**: Not thread-safe.
+
+## Configurable Options
+
+| Field | Type | Default | Range | Description |
+|-------|------|---------|-------|-------------|
+| `max_connections` | size_t | 2048 | 1-65535 | Max concurrent connections |
+| `keepalive_timeout` | int | 60 | 0-3600 | Keep-alive timeout (seconds) |
+| `request_timeout` | int | 30 | 1-3600 | Request timeout (seconds) |
+| `max_header_size` | size_t | 8192 | 256-65536 | Max header size (bytes) |
+| `max_body_size` | size_t | 10485760 | 1024-1073741824 | Max body size (bytes) |
+| `max_headers` | int | 64 | 8-256 | Max header count |
+| `read_buffer_size` | size_t | 4096 | 256-65536 | Read buffer size (bytes) |
+| `backlog` | int | 128 | 0-65535 | TCP listen backlog |
+| `tcp_nodelay` | int | 1 | 0-1 | TCP_NODELAY |
+| `tcp_keepalive` | int | 1 | 0-1 | TCP keepalive |
+| `websocket_max_frame_size` | size_t | 65536 | 1024-1048576 | Max WebSocket frame (bytes) |
+| `websocket_ping_interval` | int | 30 | 5-300 | Ping interval (seconds) |
+| `websocket_ping_timeout` | int | 10 | 3-60 | Ping timeout (seconds) |
+
+## Behavior Rules
+
+1. **Defaults**: All fields have sensible defaults. Callers can create a config and only change the fields they need.
+
+2. **Validation**: `uvhttp_config_validate` checks all fields against their valid ranges. Out-of-range values return `UVHTTP_ERROR_INVALID_PARAM`.
+
+3. **Immutability**: Config should not be modified while the server is listening. Changes take effect on the next listen.
+
+## Test Requirements
+
+- Config creation with defaults
+- Individual field modification
+- Validation of valid and invalid values
+- Boundary testing (min/max for each field)
+- NULL parameter handling
+- Config free (no-op on NULL)
+- Config set/get on context
+- Complete workflow (create, modify, validate, use, free)

--- a/docs/spec/connection-api.md
+++ b/docs/spec/connection-api.md
@@ -1,0 +1,86 @@
+# Connection API Spec
+
+## Overview
+
+The Connection module manages TCP connections, HTTP parsing via llhttp,
+request/response lifecycle, and connection cleanup. Each connection is tied
+to a single TCP socket and handles one or more HTTP requests (keep-alive).
+
+## Interfaces
+
+### uvhttp_connection_new
+- **Signature**: `uvhttp_error_t uvhttp_connection_new(uvhttp_server_t* server, uvhttp_connection_t** conn)`
+- **Purpose**: Create a new connection object for an accepted TCP socket
+- **Preconditions**: `server` must be valid. `conn` must be non-NULL.
+- **Postconditions**: On success, `*conn` points to a valid connection with `state=UVHTTP_CONN_STATE_NEW`, `server` set, `tcp_handle` initialized.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: server or conn is NULL
+  - `UVHTTP_ERROR_OUT_OF_MEMORY`: allocation failure
+  - `UVHTTP_ERROR_CONNECTION_LIMIT`: server is at max connections
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_connection_start
+- **Signature**: `uvhttp_error_t uvhttp_connection_start(uvhttp_connection_t* conn)`
+- **Purpose**: Start reading from the connection
+- **Preconditions**: `conn` must be valid, in NEW state.
+- **Postconditions**: State transitions to `UVHTTP_CONN_STATE_HTTP_READING`. Read callback is registered.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: conn is NULL
+  - `UVHTTP_ERROR_CONNECTION_INIT`: failed to start reading
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_connection_close
+- **Signature**: `void uvhttp_connection_close(uvhttp_connection_t* conn)`
+- **Purpose**: Initiate connection close. Resources are freed in the close callback.
+- **Preconditions**: `conn` must be valid. Can be NULL (no-op).
+- **Postconditions**: TCP handle close is initiated. Resources are freed in `on_handle_close` callback.
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_connection_free
+- **Signature**: `void uvhttp_connection_free(uvhttp_connection_t* conn)`
+- **Purpose**: Free connection resources immediately
+- **Preconditions**: `conn` must be valid. Should only be called after close is complete.
+- **Postconditions**: All connection memory is freed. The `freed` flag prevents double-free.
+- **Error conditions**: NULL conn is a no-op.
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_connection_set_state
+- **Signature**: `void uvhttp_connection_set_state(uvhttp_connection_t* conn, uvhttp_connection_state_t state)`
+- **Purpose**: Update connection state
+- **Preconditions**: `conn` must be valid.
+- **Postconditions**: `conn->state` is updated.
+- **Thread safety**: Not thread-safe.
+
+## Connection States
+
+```
+NEW → HTTP_READING → (request complete) → HTTP_WRITING → (response sent) → HTTP_READING
+NEW → HTTP_READING → (error) → CLOSING → CLOSED
+NEW → HTTP_READING → (upgrade) → WEBSOCKET_OPEN → WEBSOCKET_CLOSING → CLOSED
+```
+
+## Behavior Rules
+
+1. **Keep-Alive**: After a response is sent, the connection returns to HTTP_READING state for the next request. The keep-alive timeout is configurable.
+
+2. **Request/response lifecycle**: Each request creates a `uvhttp_request_t` and `uvhttp_response_t` pair. These are recycled for keep-alive connections.
+
+3. **Error handling**: Parse errors, timeout, or connection reset transition to CLOSING state. The error is logged and the connection is cleaned up.
+
+4. **Double-free protection**: The `freed` flag prevents double-free. All cleanup functions check this flag before proceeding.
+
+5. **TLS support**: When TLS is enabled, read/write operations go through mbedtls SSL functions instead of raw TCP.
+
+6. **WebSocket upgrade**: When a WebSocket upgrade request is detected, the connection transitions to WebSocket mode.
+
+## Test Requirements
+
+- Connection creation and destruction
+- State transitions
+- Keep-Alive request/response cycle
+- Error handling (parse errors, timeout)
+- Double-free protection
+- TLS connection lifecycle
+- WebSocket upgrade path
+- NULL parameter handling for all public functions
+- Connection limit enforcement

--- a/docs/spec/error-api.md
+++ b/docs/spec/error-api.md
@@ -1,0 +1,97 @@
+# Error API Spec
+
+## Overview
+
+The Error module provides a unified error code system and error handling
+utilities. All public API functions return `uvhttp_error_t` codes.
+
+## Error Code Hierarchy
+
+```
+UVHTTP_OK (0)
+├── General Errors (-1 to -9)
+│   ├── UVHTTP_ERROR_INVALID_PARAM (-1)
+│   ├── UVHTTP_ERROR_OUT_OF_MEMORY (-2)
+│   ├── UVHTTP_ERROR_NOT_FOUND (-3)
+│   ├── UVHTTP_ERROR_NULL_POINTER (-5)
+│   └── UVHTTP_ERROR_TIMEOUT (-7)
+├── Server Errors (-100 to -106)
+│   ├── UVHTTP_ERROR_SERVER_INIT (-100)
+│   ├── UVHTTP_ERROR_SERVER_LISTEN (-101)
+│   └── UVHTTP_ERROR_CONNECTION_LIMIT (-103)
+├── Connection Errors (-200 to -207)
+│   ├── UVHTTP_ERROR_CONNECTION_INIT (-200)
+│   └── UVHTTP_ERROR_CONNECTION_TIMEOUT (-205)
+├── Request/Response Errors (-300 to -309)
+│   ├── UVHTTP_ERROR_REQUEST_INIT (-300)
+│   ├── UVHTTP_ERROR_RESPONSE_SEND (-302)
+│   ├── UVHTTP_ERROR_HEADER_TOO_LARGE (-305)
+│   └── UVHTTP_ERROR_BODY_TOO_LARGE (-306)
+├── TLS Errors (-400 to -418)
+│   ├── UVHTTP_ERROR_TLS_INIT (-400)
+│   └── UVHTTP_ERROR_TLS_HANDSHAKE (-402)
+├── Router Errors (-500 to -504)
+│   └── UVHTTP_ERROR_ROUTE_NOT_FOUND (-500)
+├── Rate Limit Error (-550)
+│   └── UVHTTP_ERROR_RATE_LIMIT_EXCEEDED (-550)
+└── WebSocket Errors (-700 to -707)
+    ├── UVHTTP_ERROR_WS_HANDSHAKE (-700)
+    └── UVHTTP_ERROR_WS_FRAME_INVALID (-702)
+```
+
+## Interfaces
+
+### uvhttp_error_string
+- **Signature**: `const char* uvhttp_error_string(uvhttp_error_t error)`
+- **Purpose**: Get a human-readable error string
+- **Preconditions**: None
+- **Returns**: A non-NULL string describing the error.
+- **Thread safety**: Thread-safe (returns static strings).
+
+### uvhttp_error_category_string
+- **Signature**: `const char* uvhttp_error_category_string(uvhttp_error_t error)`
+- **Purpose**: Get the error category (e.g., "Server", "Connection")
+- **Preconditions**: None
+- **Returns**: A non-NULL string with the category name.
+- **Thread safety**: Thread-safe.
+
+### uvhttp_error_description
+- **Signature**: `const char* uvhttp_error_description(uvhttp_error_t error)`
+- **Purpose**: Get a detailed error description
+- **Preconditions**: None
+- **Returns**: A non-NULL string with the description.
+- **Thread safety**: Thread-safe.
+
+### uvhttp_error_suggestion
+- **Signature**: `const char* uvhttp_error_suggestion(uvhttp_error_t error)`
+- **Purpose**: Get a suggested fix for the error
+- **Preconditions**: None
+- **Returns**: A non-NULL string with the suggestion.
+- **Thread safety**: Thread-safe.
+
+### uvhttp_error_is_recoverable
+- **Signature**: `int uvhttp_error_is_recoverable(uvhttp_error_t error)`
+- **Purpose**: Check if the error is recoverable
+- **Preconditions**: None
+- **Returns**: 1 if recoverable, 0 if fatal.
+- **Thread safety**: Thread-safe.
+
+## Behavior Rules
+
+1. **All functions return strings**: Error string functions always return a non-NULL string, even for unknown error codes.
+
+2. **Unknown error codes**: If an error code is not in the known range, the functions return a generic "Unknown error" message.
+
+3. **Error codes are negative**: All error codes are negative integers. `UVHTTP_OK` (0) is the only non-error value.
+
+4. **TLS "want read/write"**: TLS functions may return positive values (1, 2) to indicate "want read" or "want write" — these are not errors.
+
+## Test Requirements
+
+- All error codes have non-NULL string representations
+- Category strings are non-NULL
+- Description strings are non-NULL
+- Suggestion strings are non-NULL
+- Recoverable check is correct for each error type
+- Unknown error codes return generic messages
+- NULL parameter handling for error helper functions

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -1,0 +1,66 @@
+# UVHTTP Specification Index
+
+This directory contains the formal specifications for the UVHTTP project,
+following Spec Driven Development (SDD) principles. Each spec defines the
+behavior contract, interfaces, and quality criteria for a module.
+
+## Spec Documents
+
+### Core API Specifications
+- [Server API Spec](server-api.md) — `uvhttp_server_t` lifecycle, listen, stop
+- [Router API Spec](router-api.md) — `uvhttp_router_t` route matching, cache
+- [Connection API Spec](connection-api.md) — `uvhttp_connection_t` lifecycle
+- [Request API Spec](request-api.md) — `uvhttp_request_t` parsing, headers, body
+- [Response API Spec](response-api.md) — `uvhttp_response_t` building, sending
+- [WebSocket API Spec](websocket-api.md) — WebSocket handshake, frames, close
+- [Static File API Spec](static-api.md) — `uvhttp_static_t` file serving, cache
+- [TLS API Spec](tls-api.md) — `uvhttp_tls_t` context, handshake, config
+- [Config API Spec](config-api.md) — `uvhttp_config_t` options, validation
+- [Error API Spec](error-api.md) — `uvhttp_error_t` codes, messages, handling
+
+### Quality Specifications
+- [Memory Safety Spec](memory-safety.md) — ASan/UBSan gates, leak policy
+- [Test Coverage Spec](test-coverage.md) — Coverage targets, test categories
+- [Performance Spec](performance.md) — Throughput, latency, resource limits
+- [Build System Spec](build-system.md) — CMake configuration, C standard, flags
+
+### Internal Specifications
+- [Allocator Spec](allocator.md) — `uvhttp_allocator_t` interface, backends
+- [Protocol Upgrade Spec](protocol-upgrade.md) — HTTP upgrade mechanism
+
+## Spec Format
+
+Each spec document follows this template:
+
+```markdown
+# Module Name Spec
+
+## Overview
+Brief description of the module's purpose and responsibilities.
+
+## Interfaces
+### Function Name
+- **Signature**: `return_type function_name(params)`
+- **Purpose**: What it does
+- **Preconditions**: What must be true before calling
+- **Postconditions**: What is true after calling
+- **Error conditions**: When it returns errors
+- **Thread safety**: Thread-safe or not
+
+## Behavior Rules
+Numbered rules that define the module's behavior contract.
+
+## Performance Requirements
+Specific throughput, latency, or memory targets.
+
+## Test Requirements
+What test scenarios must exist.
+```
+
+## Compliance
+
+Each spec is verified by:
+1. **Static analysis**: Code review against spec rules
+2. **Unit tests**: Test cases covering each spec requirement
+3. **Integration tests**: End-to-end scenarios
+4. **CI gates**: Automated checks on every PR

--- a/docs/spec/memory-safety.md
+++ b/docs/spec/memory-safety.md
@@ -1,0 +1,94 @@
+# Memory Safety Spec
+
+## Overview
+
+UVHTTP guarantees memory safety for long-running production services and
+embedded devices. This spec defines the memory safety criteria that all code
+must satisfy before being merged.
+
+## Sanitizer Gates
+
+### AddressSanitizer (ASan)
+- **Requirement**: The full test suite (91 tests) must pass with zero findings under ASan with leak detection enabled.
+- **Build**: `cmake -B build_asan -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON`
+- **Run**: `cd build_asan && ctest --output-on-failure`
+- **CI gate**: `.github/workflows/ci-pr.yml` — every PR must pass ASan
+
+### UndefinedBehaviorSanitizer (UBSan)
+- **Requirement**: The full test suite must pass with zero findings under UBSan.
+- **Build**: `cmake -B build_ubsan -DCMAKE_BUILD_TYPE=Debug -DENABLE_UBSAN=ON`
+- **Run**: `cd build_ubsan && ctest --output-on-failure`
+- **CI gate**: `.github/workflows/ci-nightly.yml` — nightly run
+
+### Why separate builds
+ASan and UBSan cannot be combined in a single build. Both must be green.
+
+## Bug Classes — Zero Tolerance
+
+The following bug classes are explicitly prohibited. The CHANGELOG documents
+all fixes applied to reach zero findings.
+
+| Bug Class | Detection | Prevention |
+|-----------|-----------|------------|
+| Heap use-after-free | ASan | NULL pointers after free, freed flag |
+| Heap buffer overflow | ASan | Bounds checking, snprintf, safe string ops |
+| Stack buffer overflow | ASan | Fixed-size buffers, snprintf |
+| Stack buffer underflow | ASan | Array index validation |
+| Memory leak | ASan (leak detection) | Alloc/free pairing, cleanup functions |
+| Double free | ASan | freed flag, NULL checks |
+| Signed integer overflow | UBSan | Bounds checking |
+| Invalid shift | UBSan | Platform-specific shift handling (32-bit) |
+| Null pointer dereference | UBSan | NULL checks on all public API params |
+| Misalignment | UBSan | Static assertions on struct layout |
+
+## Reproduce Command
+
+```bash
+make verify-memory-safety
+```
+
+This builds and runs both ASan and UBSan configurations. A clean run prints:
+```
+==> PASS: full suite clean under ASan and UBSan (91/91 each).
+```
+
+## Defense in Depth
+
+Beyond sanitizers, the codebase applies:
+
+1. **Compile-time hardening**:
+   - `-Werror` with `-Wall -Wextra -Wformat=2 -Wformat-security`
+   - `-fstack-protector-strong`, `-fno-common`
+   - Full RELRO (`-Wl,-z,relro,now`)
+   - `_FORTIFY_SOURCE=2`
+
+2. **Safe string operations**: No `strcpy` or `sprintf`. All string operations
+   use `snprintf` or `uvhttp_safe_strcpy` (which wraps snprintf).
+
+3. **Input validation**: URL length, path traversal, header size/format, body
+   size limits are checked before any buffer operation.
+
+4. **Response splitting guards**: All header values are checked for control
+   characters before emission.
+
+5. **Idempotent cleanup**: All `*_cleanup` / `*_free_resources` paths NULL
+   pointers after freeing and guard on a `freed` flag.
+
+## Fuzzing
+
+The router module is fuzzed nightly with libFuzzer + ASan:
+
+```bash
+./fuzz_router -max_total_time=60 -max_len=256
+```
+
+The fuzzer already found one real bug (heap-buffer-overflow in
+`add_route_method`) that the unit tests never hit.
+
+## Leak Policy
+
+- **Zero tolerance**: Any leak detected by ASan is a release blocker
+- **False positives**: ASan false positives (e.g., stack frame reuse) must be
+  documented with a `no_sanitize("address")` attribute and a comment
+  explaining the false positive
+- **Leak detection**: ASan is configured with `detect_leaks=1`

--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -1,0 +1,71 @@
+# Performance Spec
+
+## Overview
+
+This spec defines the performance benchmarks, throughput targets, latency
+budgets, and resource limits that UVHTTP must satisfy. All measurements are
+taken on the reference benchmark host.
+
+## Reference Benchmark Host
+
+- **CPU**: AMD Ryzen 7 5800H, 12 cores
+- **OS**: Linux 6.17.13-2-pve
+- **Compiler**: GCC 11.4.0 Release build (`-O2 -DNDEBUG`)
+- **Allocator**: System allocator
+- **Test tool**: wrk 4.1.0
+- **Test duration**: 10 seconds per run
+- **Server**: built-in `test_performance_e2e`
+
+## Throughput Requirements
+
+| Scenario | Connections | Min RPS | Target RPS | Notes |
+|----------|-------------|---------|------------|-------|
+| Low concurrency | 10 | 18,000 | 19,887 | P50 < 0.5ms |
+| Medium concurrency | 100 | 18,000 | 19,834 | Flat vs low |
+| High concurrency | 500 | 18,000 | 19,810 | Flat vs 100 |
+| Extreme concurrency | 1000 | 16,000 | 18,518 | Graceful degradation |
+| JSON endpoint | 100 | 17,000 | 19,451 | |
+| Large response 1KB | 100 | 17,000 | 19,524 | |
+| **Socket errors** | **All** | **0** | **0** | Zero tolerance |
+
+## Latency Requirements
+
+| Percentile | Latency Budget |
+|------------|----------------|
+| P50 | < 5ms |
+| P90 | < 10ms |
+| P95 | < 15ms |
+| P99 | < 25ms |
+
+## Memory Requirements
+
+| Metric | Budget | Notes |
+|--------|--------|-------|
+| Static library size | < 300 KB | Stripped Release build |
+| Per-server instance | < 512 bytes | Plus per-connection allocations |
+| Per-connection | < 4 KB | Request + response + buffers |
+| Steady-state RSS | Flat | No growth under sustained load |
+| Cold start | < 500ms | First byte after launch |
+
+## Long-Run Stability
+
+Under sustained load (100 connections, 60+ seconds), the server's RSS must
+not grow. Measured with `scripts/performance/long_run_memory.sh`.
+
+## Optimization Features
+
+| Feature | Status | Impact |
+|---------|--------|--------|
+| Keep-Alive connection reuse | Active | ~1000x vs per-request |
+| O(1) route lookup (trie) | Active | Eliminates linear scan |
+| LRU cache for static files | Active | Reduces disk I/O |
+| Zero-copy sendfile | Active | 50%+ CPU reduction for large files |
+| Direct libuv calls | Design | No abstraction layer |
+| Compile-time feature selection | Active | No runtime overhead for unused features |
+
+## Test Requirements
+
+- Performance regression test on every PR (via CI)
+- Benchmark results must be reproducible
+- Historical baseline stored in `docs/performance/baseline-history.json`
+- RPS degradation > 5% from baseline must be investigated

--- a/docs/spec/request-api.md
+++ b/docs/spec/request-api.md
@@ -1,0 +1,105 @@
+# Request API Spec
+
+## Overview
+
+The Request module parses incoming HTTP requests using llhttp, provides
+access to request method, path, headers, query parameters, and body.
+
+## Interfaces
+
+### uvhttp_request_init
+- **Signature**: `uvhttp_error_t uvhttp_request_init(uvhttp_request_t* request, uv_tcp_t* client)`
+- **Purpose**: Initialize a request object for a client connection
+- **Preconditions**: `request` must be a valid pointer to uninitialized memory. `client` must be a valid TCP handle.
+- **Postconditions**: Request is initialized with empty state, ready for parsing.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: request or client is NULL
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_request_cleanup
+- **Signature**: `void uvhttp_request_cleanup(uvhttp_request_t* request)`
+- **Purpose**: Free request resources (body, headers)
+- **Preconditions**: `request` must be valid.
+- **Postconditions**: All allocated fields are freed. Pointers are NULLed.
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_request_get_method
+- **Signature**: `const char* uvhttp_request_get_method(const uvhttp_request_t* request)`
+- **Purpose**: Get the HTTP method string
+- **Preconditions**: `request` must be valid.
+- **Returns**: Method string (e.g., "GET", "POST"), or NULL if not yet parsed.
+- **Thread safety**: Thread-safe for reads.
+
+### uvhttp_request_get_path
+- **Signature**: `const char* uvhttp_request_get_path(const uvhttp_request_t* request)`
+- **Purpose**: Get the request path
+- **Preconditions**: `request` must be valid.
+- **Returns**: Path string (e.g., "/api/users"), or NULL if not yet parsed.
+- **Thread safety**: Thread-safe for reads.
+
+### uvhttp_request_get_header
+- **Signature**: `const char* uvhttp_request_get_header(const uvhttp_request_t* request, const char* name)`
+- **Purpose**: Get a specific header value
+- **Preconditions**: `request` must be valid. `name` must be non-NULL.
+- **Returns**: Header value string, or NULL if not found.
+- **Error conditions**: Returns NULL if request or name is NULL.
+- **Thread safety**: Thread-safe for reads.
+
+### uvhttp_request_get_query_param
+- **Signature**: `const char* uvhttp_request_get_query_param(const uvhttp_request_t* request, const char* name)`
+- **Purpose**: Get a specific query parameter value
+- **Preconditions**: `request` must be valid. `name` must be non-NULL.
+- **Returns**: Parameter value string, or NULL if not found.
+- **Thread safety**: Thread-safe for reads.
+
+### uvhttp_request_get_body
+- **Signature**: `const char* uvhttp_request_get_body(const uvhttp_request_t* request)`
+- **Purpose**: Get the request body
+- **Preconditions**: `request` must be valid.
+- **Returns**: Body pointer, or NULL if empty.
+- **Thread safety**: Thread-safe for reads.
+
+### uvhttp_request_get_body_length
+- **Signature**: `size_t uvhttp_request_get_body_length(const uvhttp_request_t* request)`
+- **Purpose**: Get the request body length
+- **Preconditions**: `request` must be valid.
+- **Returns**: Body length in bytes.
+- **Thread safety**: Thread-safe for reads.
+
+### uvhttp_request_get_client_ip
+- **Signature**: `const char* uvhttp_request_get_client_ip(const uvhttp_request_t* request)`
+- **Purpose**: Get the client IP address
+- **Preconditions**: `request` must be valid.
+- **Returns**: IP address string.
+- **Thread safety**: Thread-safe for reads.
+
+### uvhttp_request_foreach_header
+- **Signature**: `void uvhttp_request_foreach_header(const uvhttp_request_t* request, void (*callback)(const char* name, const char* value, void* user_data), void* user_data)`
+- **Purpose**: Iterate over all request headers
+- **Preconditions**: `request` must be valid. `callback` must be non-NULL.
+- **Thread safety**: Thread-safe for reads.
+
+## Behavior Rules
+
+1. **Parsing**: HTTP parsing is done via llhttp callbacks. The request object is populated incrementally as data arrives.
+
+2. **Header limits**: Maximum header count is `UVHTTP_MAX_HEADERS` (64). Maximum header name length is 256 bytes. Maximum header value length is 4096 bytes.
+
+3. **URL limits**: Maximum URL length is 2048 bytes. Path traversal (`../`) is checked and rejected.
+
+4. **Body limits**: Maximum body size is configurable (default 10 MB). Larger bodies are rejected.
+
+5. **Query parsing**: Query parameters are parsed from the URL. Parameter names and values are validated for dangerous characters.
+
+6. **Header validation**: Header names must be alphanumeric with hyphens. Header values are checked for control characters.
+
+## Test Requirements
+
+- Method, path, header access
+- Query parameter extraction
+- Body access
+- NULL parameter handling for all accessors
+- Header iteration
+- URL validation (path traversal rejection)
+- Maximum limits enforcement
+- Empty request handling

--- a/docs/spec/response-api.md
+++ b/docs/spec/response-api.md
@@ -1,0 +1,84 @@
+# Response API Spec
+
+## Overview
+
+The Response module builds and sends HTTP responses. It provides functions
+to set response status, headers, body, and control response sending.
+
+## Interfaces
+
+### uvhttp_response_set_status
+- **Signature**: `uvhttp_error_t uvhttp_response_set_status(uvhttp_response_t* response, int status_code)`
+- **Purpose**: Set the HTTP response status code
+- **Preconditions**: `response` must be valid. `status_code` should be a valid HTTP status code.
+- **Postconditions**: `response->status_code` is set.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: response is NULL
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_response_set_header
+- **Signature**: `uvhttp_error_t uvhttp_response_set_header(uvhttp_response_t* response, const char* name, const char* value)`
+- **Purpose**: Set a response header
+- **Preconditions**: `response` must be valid. `name` and `value` must be non-NULL.
+- **Postconditions**: The header is added to the response. If the header already exists, it is overwritten.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: response, name, or value is NULL
+  - Header value contains control characters (response splitting guard)
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_response_set_body
+- **Signature**: `uvhttp_error_t uvhttp_response_set_body(uvhttp_response_t* response, const char* body, size_t length)`
+- **Purpose**: Set the response body
+- **Preconditions**: `response` must be valid. `body` can be NULL (empty body).
+- **Postconditions**: The body is copied into the response. Content-Length is NOT set automatically.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: response is NULL
+  - `UVHTTP_ERROR_OUT_OF_MEMORY`: allocation failure
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_response_send
+- **Signature**: `uvhttp_error_t uvhttp_response_send(uvhttp_response_t* response)`
+- **Purpose**: Send the response to the client
+- **Preconditions**: `response` must be valid. Status code must be set.
+- **Postconditions**: The response is sent. Headers are flushed, then the body is sent.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: response is NULL
+  - `UVHTTP_ERROR_RESPONSE_SEND`: write failure
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_response_cleanup
+- **Signature**: `void uvhttp_response_cleanup(uvhttp_response_t* response)`
+- **Purpose**: Free response resources
+- **Preconditions**: `response` must be valid.
+- **Postconditions**: All allocated fields are freed. Pointers are NULLed.
+- **Thread safety**: Not thread-safe.
+
+## Behavior Rules
+
+1. **Response ownership**: The framework creates the response object. The handler does not need to allocate or free it.
+
+2. **Content-Type**: The handler must set Content-Type explicitly. The framework does not auto-detect.
+
+3. **Content-Length**: The framework sets Content-Length from the body length. If no body is set, Content-Length is 0.
+
+4. **Response splitting guard**: All header values are checked for control characters (`\r`, `\n`, `\0`) before emission. If detected, the header is rejected.
+
+5. **Error responses**: When an error handler is invoked, it should set an appropriate status code (4xx/5xx) and return an error body.
+
+6. **Large responses**: For large bodies (>1MB), the handler should use chunked encoding or sendfile for static files.
+
+## Performance Requirements
+
+- Header emission: O(n) where n = header count
+- Body sending: O(body size) for small bodies, zero-copy for large files
+- Response header buffer: 4096 bytes (configurable)
+
+## Test Requirements
+
+- Status code setting
+- Header setting and overwriting
+- Body setting (empty, small, large)
+- Response sending
+- NULL parameter handling for all functions
+- Response splitting guard (control character rejection)
+- Cleanup (no leaks)

--- a/docs/spec/router-api.md
+++ b/docs/spec/router-api.md
@@ -1,0 +1,108 @@
+# Router API Spec
+
+## Overview
+
+The Router module maps HTTP request paths and methods to handler functions.
+It supports two routing strategies: array-based (for small route sets) and
+trie-based (for large route sets with prefix matching). Transition between
+the two modes is automatic.
+
+## Interfaces
+
+### uvhttp_router_new
+- **Signature**: `uvhttp_error_t uvhttp_router_new(uvhttp_router_t** router)`
+- **Purpose**: Create a new router instance
+- **Preconditions**: `router` must be a non-NULL pointer to `uvhttp_router_t*`
+- **Postconditions**: On success, `*router` points to a valid router with `route_count=0`, `use_trie=0`, `array_routes=NULL`, `node_pool=NULL`.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: `router` is NULL
+  - `UVHTTP_ERROR_OUT_OF_MEMORY`: allocation failure
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_router_free
+- **Signature**: `void uvhttp_router_free(uvhttp_router_t* router)`
+- **Purpose**: Free all router resources
+- **Preconditions**: `router` must be valid (from `uvhttp_router_new`). Can be NULL (no-op).
+- **Postconditions**: All memory is freed. The router pointer is invalid after return.
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_router_add_route
+- **Signature**: `uvhttp_error_t uvhttp_router_add_route(uvhttp_router_t* router, const char* path, uvhttp_request_handler_t handler)`
+- **Purpose**: Add a route for all HTTP methods
+- **Preconditions**: `router` must be valid. `path` must be non-NULL. `handler` must be non-NULL.
+- **Postconditions**: The route is added to the router. If the route count exceeds the array threshold, automatic migration to trie mode occurs.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: `router`, `path`, or `handler` is NULL
+  - `UVHTTP_ERROR_OUT_OF_MEMORY`: allocation failure
+  - `UVHTTP_ERROR_NOT_FOUND`: route count exceeds MAX_ROUTES
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_router_add_route_method
+- **Signature**: `uvhttp_error_t uvhttp_router_add_route_method(uvhttp_router_t* router, const char* path, uvhttp_method_t method, uvhttp_request_handler_t handler)`
+- **Purpose**: Add a route for a specific HTTP method
+- **Preconditions**: Same as `uvhttp_router_add_route`, plus `method` must be a valid `uvhttp_method_t`.
+- **Postconditions**: Same as `uvhttp_router_add_route`, but the route is only matched for the specified method.
+- **Error conditions**: Same as `uvhttp_router_add_route`.
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_router_find_handler
+- **Signature**: `uvhttp_request_handler_t uvhttp_router_find_handler(const uvhttp_router_t* router, const char* path, const char* method)`
+- **Purpose**: Find the handler for a given path and method
+- **Preconditions**: `router` must be valid. `path` must be non-NULL. `method` must be a valid HTTP method string.
+- **Postconditions**: Returns the matching handler, or NULL if no match is found.
+- **Thread safety**: Thread-safe for reads after all routes are added.
+
+### uvhttp_router_match
+- **Signature**: `uvhttp_error_t uvhttp_router_match(const uvhttp_router_t* router, const char* path, const char* method, uvhttp_route_match_t* match)`
+- **Purpose**: Match a path and extract path parameters
+- **Preconditions**: Same as `uvhttp_router_find_handler`, plus `match` must be non-NULL.
+- **Postconditions**: On success, `match->handler` is set, `match->params` contains extracted parameters, `match->param_count` is set.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: any argument is NULL
+  - `UVHTTP_ERROR_NOT_FOUND`: no matching route
+- **Thread safety**: Thread-safe for reads.
+
+## Route Path Syntax
+
+- `/users` — exact match
+- `/users/:id` — parameter match (extracts `id` from path segment)
+- `/static/*` — prefix match (matches any path starting with `/static/`)
+- `/api/v1/users` — static prefix with multiple segments
+
+## Behavior Rules
+
+1. **Array mode**: Routes are stored in a flat array. Matching is O(n) linear scan. Used when route count is below the migration threshold.
+
+2. **Trie mode**: Routes are stored in a compact prefix trie (128-byte nodes). Matching is O(k) where k is the path length. Used after automatic migration.
+
+3. **Automatic migration**: When the route count exceeds the array threshold (default: 8), the array is migrated to a trie. Migration is transparent: all routes remain functional.
+
+4. **Parameter extraction**: Path parameters (`:param`) are extracted during matching. Parameters are stored in `uvhttp_route_match_t::params`.
+
+5. **Wildcard routes**: The `*` wildcard matches any path prefix. Wildcard routes have the lowest priority.
+
+6. **Method matching**: When a route is added with a specific method, only requests with that method match. Routes added without a method match all methods.
+
+7. **Fallback handler**: If set, the fallback handler is called when no route matches. The fallback handler is the last resort before returning 404.
+
+## Performance Requirements
+
+- Array mode matching: O(n) where n = route count
+- Trie mode matching: O(k) where k = path segment count
+- Route addition: O(1) amortized (array mode), O(k) (trie mode)
+- Node size: 128 bytes (2 cache lines)
+- Memory: ~128 bytes per route (trie mode), ~512 bytes per route (array mode)
+- Migration: automatic, transparent
+
+## Test Requirements
+
+- Route addition (all methods, specific methods, wildcard, parameter)
+- Route matching (exact, prefix, parameter, method-specific)
+- Non-matching routes return NULL handler
+- Array-to-trie migration
+- NULL parameter handling for all public functions
+- Maximum route count enforcement
+- Parameter extraction correctness
+- Fallback handler behavior
+- Static file route registration
+- Memory cleanup (no leaks on free)

--- a/docs/spec/server-api.md
+++ b/docs/spec/server-api.md
@@ -1,0 +1,122 @@
+# Server API Spec
+
+## Overview
+
+The Server module manages the HTTP server lifecycle: creation, binding,
+listening, connection acceptance, and graceful shutdown. It is the top-level
+object that ties together the event loop, router, TLS context, and WebSocket
+connection management.
+
+## Interfaces
+
+### uvhttp_server_new
+- **Signature**: `uvhttp_error_t uvhttp_server_new(uv_loop_t* loop, uvhttp_server_t** server)`
+- **Purpose**: Create a new HTTP server instance
+- **Preconditions**: `loop` must be a valid, initialized `uv_loop_t`. `server` must be a non-NULL pointer to a `uvhttp_server_t*` that will receive the result.
+- **Postconditions**: On success, `*server` points to a valid server with `is_listening=0`, `freed=0`, `active_connections=0`, `handler=NULL`, `router=NULL`, `config=NULL`, `context=NULL`, `tls_ctx=NULL`.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: `loop` or `server` is NULL
+  - `UVHTTP_ERROR_OUT_OF_MEMORY`: allocation failure
+- **Thread safety**: Not thread-safe. Must be called from the event loop thread.
+
+### uvhttp_server_listen
+- **Signature**: `uvhttp_error_t uvhttp_server_listen(uvhttp_server_t* server, const char* host, int port)`
+- **Purpose**: Bind to a host:port and start accepting connections
+- **Preconditions**: `server` must be valid (created by `uvhttp_server_new`), not already listening. A handler or router must have been set.
+- **Postconditions**: On success, `server->is_listening=1`, the TCP handle is bound and listening. On failure, server state is unchanged.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: `server` or `host` is NULL
+  - `UVHTTP_ERROR_SERVER_LISTEN`: bind or listen syscall failed
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_server_stop
+- **Signature**: `uvhttp_error_t uvhttp_server_stop(uvhttp_server_t* server)`
+- **Purpose**: Stop accepting new connections. Existing connections continue.
+- **Preconditions**: `server` must be listening.
+- **Postconditions**: `server->is_listening=0`. The TCP handle is closed.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: `server` is NULL
+  - `UVHTTP_ERROR_NOT_FOUND`: server is not listening
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_server_free
+- **Signature**: `uvhttp_error_t uvhttp_server_free(uvhttp_server_t* server)`
+- **Purpose**: Free all server resources. Must be called after stop.
+- **Preconditions**: `server` must be valid. Should not be listening (call `stop` first).
+- **Postconditions**: All server memory is freed. The `freed` flag prevents double-free. Any remaining connections are cleaned up.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: `server` is NULL
+  - Double-free is handled gracefully (returns UVHTTP_OK on second call)
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_server_set_handler
+- **Signature**: `uvhttp_error_t uvhttp_server_set_handler(uvhttp_server_t* server, uvhttp_request_handler_t handler)`
+- **Purpose**: Set the default request handler for all requests
+- **Preconditions**: `server` must be valid. `handler` must be non-NULL.
+- **Postconditions**: `server->handler` is set to the provided handler.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: `server` or `handler` is NULL
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_server_set_router
+- **Signature**: `uvhttp_error_t uvhttp_server_set_router(uvhttp_server_t* server, uvhttp_router_t* router)`
+- **Purpose**: Attach a router for path-based request dispatching
+- **Preconditions**: `server` must be valid. `router` must be a valid router.
+- **Postconditions**: `server->router` is set. The server does not own the router; the caller must free it after the server.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: `server` or `router` is NULL
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_server_set_context
+- **Signature**: `uvhttp_error_t uvhttp_server_set_context(uvhttp_server_t* server, struct uvhttp_context* context)`
+- **Purpose**: Attach a context object for shared state
+- **Preconditions**: `server` must be valid. `context` must be a valid context.
+- **Postconditions**: `server->context` is set.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: `server` or `context` is NULL
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_server_enable_tls / uvhttp_server_disable_tls
+- **Signature**: `uvhttp_error_t uvhttp_server_enable_tls(uvhttp_server_t* server, uvhttp_tls_context_t* tls_ctx)` / `uvhttp_error_t uvhttp_server_disable_tls(uvhttp_server_t* server)`
+- **Purpose**: Enable or disable TLS on the server
+- **Preconditions**: `server` must be valid. TLS must be compiled in (`UVHTTP_FEATURE_TLS`).
+- **Postconditions**: `server->tls_enabled` is set accordingly.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: `server` is NULL
+  - `UVHTTP_ERROR_TLS_INIT`: TLS context is invalid
+- **Thread safety**: Not thread-safe.
+- **Feature gate**: `#if UVHTTP_FEATURE_TLS`
+
+## Behavior Rules
+
+1. **Server-request binding**: Each incoming connection creates a `uvhttp_request_t` and `uvhttp_response_t` pair. The handler is called once per request.
+
+2. **Handler dispatch priority**: If a router is set, the router is consulted first. If the router finds a matching handler, it is used. Otherwise, the default handler is used.
+
+3. **Connection limit**: The server enforces `max_connections`. When the limit is reached, new connections receive a 503 response.
+
+4. **Graceful shutdown**: `uvhttp_server_stop` stops accepting new connections. Existing connections are allowed to complete. `uvhttp_server_free` cleans up all resources.
+
+5. **Double-free protection**: The `freed` flag prevents double-free. Calling `uvhttp_server_free` twice is safe.
+
+6. **Rate limiting**: When enabled, the server tracks request count per time window. When the limit is exceeded, new requests receive a 429 response.
+
+## Performance Requirements
+
+- Connection acceptance: O(1) per new connection
+- Handler dispatch: O(1) when router cache is used
+- Memory: ~256 bytes per server instance (plus per-connection allocations)
+
+## Test Requirements
+
+- Server creation and destruction (with and without router, config, context)
+- Listen on valid and invalid hosts/ports
+- Stop and restart
+- Multiple server instances on the same loop
+- Connection limit enforcement
+- Double-free protection
+- Rate limiting enable/disable/check
+- TLS enable/disable
+- WebSocket connection management enable/disable
+- Handler dispatch with router and without
+- Server configuration via builder API

--- a/docs/spec/test-coverage.md
+++ b/docs/spec/test-coverage.md
@@ -1,0 +1,89 @@
+# Test Coverage Spec
+
+## Overview
+
+This spec defines the test coverage targets, test categories, and quality
+criteria for the UVHTTP test suite.
+
+## Test Suite
+
+- **Framework**: Google Test (C++), with some C integration tests
+- **Total tests**: 91 unit tests
+- **Integration tests**: 20 standalone C programs
+- **Fuzz harness**: 1 (router)
+
+## Coverage Targets
+
+| Module | Current | Target | Priority |
+|--------|---------|--------|----------|
+| uvhttp_version.c | 98.3% | 95% | Low |
+| uvhttp_error.c | 98.8% | 95% | Low |
+| uvhttp_utils.c | 100.0% | 95% | Low |
+| uvhttp_router.c | 62.9% | 80% | High |
+| uvhttp_connection.c | 42.8% | 70% | High |
+| uvhttp_server.c | ~50% | 70% | High |
+| uvhttp_request.c | ~60% | 70% | High |
+| uvhttp_response.c | ~60% | 70% | High |
+| uvhttp_static.c | ~40% | 60% | Medium |
+| uvhttp_websocket.c | ~50% | 60% | Medium |
+| uvhttp_tls.c | ~40% | 60% | Medium |
+| **Overall** | **~50%** | **80%** | **High** |
+
+## Test Categories
+
+### Unit Tests (91 files)
+- Test individual functions in isolation
+- Use Google Test framework
+- Use libuv mock for dependency isolation
+- Cover normal paths, error paths, and boundary conditions
+- Each test file corresponds to one source module
+
+### Integration Tests (20 files)
+- Test end-to-end scenarios with real libuv
+- Standalone C programs that start a server and test it
+- Cover HTTP methods, TLS, WebSocket, rate limiting, static files
+- Not automatically registered with CTest (manual execution)
+
+### Fuzz Tests (1 harness)
+- libFuzzer harness for router path matching
+- Runs with ASan for memory safety
+- 60 seconds per target in CI
+- 256 byte max input length
+
+## Test Quality Criteria
+
+1. **Every public API function must have at least one test**
+2. **NULL parameter paths must be tested for every public function**
+3. **Error conditions must be tested (not just success paths)**
+4. **Boundary conditions must be tested (min/max values)**
+5. **Tests must be independent** — no shared mutable state between tests
+6. **Tests must not leak memory** — verified by ASan
+7. **Tests must be deterministic** — no timing-dependent assertions
+
+## Test Naming
+
+- Test files: `test_<module>_<functionality>.cpp`
+- Test cases: `TEST(<Module>Test, <TestCaseName>)` or `TEST_F(<Module>Test, <TestCaseName>)`
+- Test case names describe the scenario: `CreateServer`, `ListenWithNullHost`, `AddRouteWithNullPath`
+
+## Running Tests
+
+```bash
+# All tests
+make -f GNUmakefile test
+
+# Specific test (via ctest)
+cd build && ctest -R "test_router"
+
+# Memory safety
+make -f GNUmakefile verify-memory-safety
+
+# Coverage
+make -f GNUmakefile coverage
+```
+
+## Continuous Verification
+
+- **PR gate**: ASan + unit tests must pass (ci-pr.yml)
+- **Nightly**: Full test suite, ASan, UBSan, fuzzing (ci-nightly.yml, ci-fuzz.yml)
+- **Coverage**: Generated nightly, published to coverage report

--- a/docs/spec/websocket-api.md
+++ b/docs/spec/websocket-api.md
@@ -1,0 +1,101 @@
+# WebSocket API Spec
+
+## Overview
+
+The WebSocket module implements RFC 6455 WebSocket protocol support. It
+handles the HTTP upgrade handshake, frame encoding/decoding, ping/pong,
+and connection management.
+
+## Interfaces
+
+### uvhttp_ws_connection_create
+- **Signature**: `struct uvhttp_ws_connection* uvhttp_ws_connection_create(int fd, mbedtls_ssl_context* ssl, int is_server, const uvhttp_config_t* config)`
+- **Purpose**: Create a WebSocket connection
+- **Preconditions**: `fd` must be a valid socket. `is_server` indicates if this is the server side.
+- **Postconditions**: Returns a valid ws_connection with CONNECTING state.
+- **Error conditions**: Returns NULL on allocation failure.
+- **Thread safety**: Not thread-safe.
+- **Feature gate**: `UVHTTP_FEATURE_WEBSOCKET`
+
+### uvhttp_ws_connection_free
+- **Signature**: `void uvhttp_ws_connection_free(struct uvhttp_ws_connection* conn)`
+- **Purpose**: Free a WebSocket connection
+- **Preconditions**: `conn` can be NULL (no-op).
+- **Postconditions**: All resources are freed.
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_ws_send_frame
+- **Signature**: `uvhttp_error_t uvhttp_ws_send_frame(uvhttp_context_t* context, struct uvhttp_ws_connection* conn, const uint8_t* data, size_t len, uvhttp_ws_opcode_t opcode)`
+- **Purpose**: Send a raw WebSocket frame
+- **Preconditions**: `conn` must be valid and in OPEN state.
+- **Postconditions**: Frame is sent to the client.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: conn is NULL or state is not OPEN
+  - Write error from underlying socket/SSL
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_ws_send_text / uvhttp_ws_send_binary
+- **Signature**: `uvhttp_error_t uvhttp_ws_send_text(uvhttp_context_t* context, struct uvhttp_ws_connection* conn, const char* text, size_t len)` / `uvhttp_error_t uvhttp_ws_send_binary(uvhttp_context_t* context, struct uvhttp_ws_connection* conn, const uint8_t* data, size_t len)`
+- **Purpose**: Send a text or binary message
+- **Preconditions**: Same as `uvhttp_ws_send_frame`
+- **Postconditions**: Message is sent as a complete WebSocket frame.
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_ws_close
+- **Signature**: `uvhttp_error_t uvhttp_ws_close(uvhttp_context_t* context, struct uvhttp_ws_connection* conn, int code, const char* reason)`
+- **Purpose**: Initiate WebSocket close handshake
+- **Preconditions**: `conn` must be valid.
+- **Postconditions**: Close frame is sent. State transitions to CLOSING.
+- **Error conditions**:
+  - `UVHTTP_ERROR_INVALID_PARAM`: conn is NULL or stale
+- **Thread safety**: Not thread-safe.
+
+### uvhttp_server_ws_broadcast
+- **Signature**: `uvhttp_error_t uvhttp_server_ws_broadcast(uvhttp_server_t* server, const char* path, const char* data, size_t len)`
+- **Purpose**: Send a message to all WebSocket clients on a path
+- **Preconditions**: `server` must be valid with connection management enabled.
+- **Postconditions**: Message is sent to all matching connections.
+- **Thread safety**: Not thread-safe.
+
+## WebSocket States
+
+```
+CONNECTING → OPEN → CLOSING → CLOSED
+```
+
+## Frame Types
+
+| Opcode | Type | Description |
+|--------|------|-------------|
+| 0x0 | Continuation | Continuation of fragmented message |
+| 0x1 | Text | UTF-8 text message |
+| 0x2 | Binary | Binary message |
+| 0x8 | Close | Close handshake |
+| 0x9 | Ping | Ping frame |
+| 0xA | Pong | Pong frame |
+
+## Behavior Rules
+
+1. **Handshake**: WebSocket upgrade is initiated via HTTP Upgrade request. The server responds with 101 Switching Protocols.
+
+2. **Frame masking**: Client frames must be masked. Server frames are not masked (per RFC 6455).
+
+3. **Fragmentation**: Large messages can be fragmented into multiple frames. The FIN bit indicates the last frame.
+
+4. **Ping/pong**: The server sends pings periodically (configurable interval). If no pong is received within the timeout, the connection is closed.
+
+5. **Connection management**: The server tracks WebSocket connections in a linked list. Connections are checked for timeout periodically.
+
+6. **Broadcast**: Messages can be broadcast to all connections on a specific path.
+
+## Test Requirements
+
+- Connection creation and destruction
+- Frame encoding/decoding
+- Text and binary message send
+- Close handshake
+- Broadcast to multiple connections
+- Connection timeout detection
+- Ping/pong cycle
+- NULL parameter handling
+- Memory cleanup (no leaks on free)


### PR DESCRIPTION
Create SDD (Spec Driven Development) specification documents covering all modules and quality criteria:

- **Server API Spec**: Lifecycle, listen, stop, TLS, rate limiting
- **Router API Spec**: Array/trie routing, matching, parameter extraction
- **Connection API Spec**: Lifecycle, states, keep-alive
- **Request API Spec**: Parsing, headers, body, validation
- **Response API Spec**: Status, headers, body, sending
- **WebSocket API Spec**: RFC 6455 frames, handshake, ping/pong
- **Config API Spec**: Options, validation, defaults
- **Error API Spec**: Error codes, hierarchy, message strings
- **Allocator Spec**: Interface, backends, memory rules
- **Memory Safety Spec**: ASan/UBSan gates, bug classes, defense in depth
- **Performance Spec**: Throughput targets, latency budgets, memory limits
- **Test Coverage Spec**: Coverage targets, test categories, quality criteria
- **Build System Spec**: CMake config, C standard, compiler flags, CI matrix

Each spec defines: interfaces with pre/postconditions, behavior rules, performance requirements, and test requirements.