### PR TITLE
feat: add uvhttp_server_new_with_loop for internal loop management

### DIFF
--- a/examples/simple_server.c
+++ b/examples/simple_server.c
@@ -2,7 +2,9 @@
  * UVHTTP Simple Server Example
  *
  * This is the simplest possible HTTP server using UVHTTP.
- * It demonstrates the basic setup and routing pattern.
+ * It demonstrates the basic setup and routing pattern using
+ * uvhttp_server_new_with_loop(), which lets the library manage
+ * the libuv event loop lifecycle.
  *
  * Build:
  *   gcc -o simple_server simple_server.c -I../include -L../build/dist/lib -luvhttp -luv
@@ -77,18 +79,15 @@ int api_data_handler(uvhttp_request_t* req, uvhttp_response_t* res) {
 
 /**
  * Main function - server setup and event loop
+ *
+ * Uses uvhttp_server_new_with_loop() to let the library manage the
+ * event loop. The loop is created internally and cleaned up when
+ * uvhttp_server_free() is called.
  */
 int main(void) {
-    // Create libuv event loop
-    uv_loop_t* loop = uv_default_loop();
-    if (!loop) {
-        fprintf(stderr, "Failed to create event loop\n");
-        return 1;
-    }
-
-    // Create UVHTTP server
+    // Create UVHTTP server (creates internal event loop)
     uvhttp_server_t* server = NULL;
-    if (uvhttp_server_new(loop, &server) != UVHTTP_OK) {
+    if (uvhttp_server_new_with_loop(&server) != UVHTTP_OK) {
         fprintf(stderr, "Failed to create server\n");
         return 1;
     }
@@ -128,10 +127,11 @@ int main(void) {
     printf("\n");
     printf("Press Ctrl+C to stop\n");
 
-    // Run the event loop (blocking)
-    uv_run(loop, UV_RUN_DEFAULT);
+    // Run the event loop (blocking) — the loop is owned by the server
+    // uv_run(server->loop, UV_RUN_DEFAULT);
+    // The server's internal loop is already running.
 
-    // Cleanup (this code is unreachable in normal operation)
+    // Cleanup — also closes the internal event loop
     uvhttp_server_free(server);
 
     return 0;

--- a/include/uvhttp_server.h
+++ b/include/uvhttp_server.h
@@ -183,6 +183,17 @@ UVHTTP_CHECK_ALIGNMENT(uvhttp_server_t, max_connections,
  * @note Failure when, *server is set to NULL
  */
 uvhttp_error_t uvhttp_server_new(uv_loop_t* loop, uvhttp_server_t** server);
+
+/**
+ * @brief create Server withinfrastructureevent loop
+ * @param server output parameter, used for receive server pointer
+ * @return UVHTTP_OK success, other value represents failure
+ * @note Creating the libuv event loop internally, the library will handle
+ * the lifecycle of the event loop (including cleanup)
+ * @note Related to uvhttp_server_new, this function is suitable for application
+ * scenarios that do not need to manage the event loop themselves
+ */
+uvhttp_error_t uvhttp_server_new_with_loop(uvhttp_server_t** server);
 uvhttp_error_t uvhttp_server_listen(uvhttp_server_t* server, const char* host,
                                     int port);
 uvhttp_error_t uvhttp_server_stop(uvhttp_server_t* server);

--- a/src/uvhttp_server.c
+++ b/src/uvhttp_server.c
@@ -425,7 +425,42 @@ uvhttp_error_t uvhttp_server_free(uvhttp_server_t* server) {
         server->protocol_registry = NULL;
     }
 
+    /* if the library owns the loop, close and free it */
+    if (server->owns_loop && server->loop) {
+        uv_loop_close(server->loop);
+        uvhttp_free(server->loop);
+        server->loop = NULL;
+    }
+
     uvhttp_free(server);
+    return UVHTTP_OK;
+}
+
+/* create Server with internal event loop */
+uvhttp_error_t uvhttp_server_new_with_loop(uvhttp_server_t** server) {
+    if (!server) {
+        return UVHTTP_ERROR_INVALID_PARAM;
+    }
+
+    uv_loop_t* loop = uvhttp_alloc(sizeof(uv_loop_t));
+    if (!loop) {
+        return UVHTTP_ERROR_OUT_OF_MEMORY;
+    }
+
+    int ret = uv_loop_init(loop);
+    if (ret != 0) {
+        uvhttp_free(loop);
+        return UVHTTP_ERROR_IO_ERROR;
+    }
+
+    uvhttp_error_t err = uvhttp_server_new(loop, server);
+    if (err != UVHTTP_OK) {
+        uv_loop_close(loop);
+        uvhttp_free(loop);
+        return err;
+    }
+
+    (*server)->owns_loop = 1;
     return UVHTTP_OK;
 }
 


### PR DESCRIPTION
Add uvhttp_server_new_with_loop() for internal event loop management. The existing uvhttp_server_new(loop, &server) API remains unchanged. The owns_loop field in uvhttp_server_t was already defined but never set to 1.