### PR TITLE
chore: remove gh-pages branch, move to GitHub Actions deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -55,7 +55,7 @@ jobs:
           npm run api:generate
           
           # Build VitePress documentation site
-          DEPLOY=gh-pages npm run build
+          DEPLOY=pages npm run build
           
           # Add .nojekyll file to disable Jekyll processing on GitHub Pages
           # This is critical for VitePress client-side routing to work correctly

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
   title: 'UVHTTP',
   titleTemplate: ':title — UVHTTP',
   description: 'Lightweight, embeddable C99 HTTP/1.1 & WebSocket server library with ASan/UBSan-verified memory safety, 32-bit embedded support, and zero-copy performance (~20K RPS).',
-  // 本地开发使用 '/'，GitHub Pages 使用 '/uvhttp/'
-  base: process.env.DEPLOY === 'gh-pages' ? '/uvhttp/' : '/',
+  // 本地开发使用 '/'，部署到 GitHub Pages 使用 '/uvhttp/'
+  base: process.env.DEPLOY === 'pages' ? '/uvhttp/' : '/',
   lang: 'en-US',
   defaultLang: 'en-US',
   i18nRouting: false,


### PR DESCRIPTION
Remove the orphan gh-pages branch and fully migrate to GitHub Actions deployment.

The deploy-docs.yml workflow already uses actions/deploy-pages@v4 for deployment. The gh-pages branch was only used for manual deployments and is no longer needed.

Also rename DEPLOY=gh-pages to DEPLOY=pages for clarity.