### PR TITLE
chore: release v2.5.1

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -2,22 +2,22 @@
 # This file defines the current version information for the project
 
 # Current version number (semantic version: MAJOR.MINOR.PATCH)
-VERSION=2.5.0
+VERSION=2.5.1
 
 # Version type: major, minor, patch
-VERSION_TYPE=minor
+VERSION_TYPE=patch
 
 # Release date
-RELEASE_DATE=2026-03-15
+RELEASE_DATE=2026-07-25
 
 # Previous version
-PREVIOUS_VERSION=2.4.4
+PREVIOUS_VERSION=2.5.0
 
 # Next version (in development)
-NEXT_VERSION=2.6.0
+NEXT_VERSION=2.5.2
 
 # Version name (optional)
-VERSION_NAME="32-bit Support & Compression"
+VERSION_NAME="Test Coverage & SDD Specs"
 
 # Whether this is a prerelease version
 IS_PRERELEASE=false

--- a/docs/guide/CHANGELOG.md
+++ b/docs/guide/CHANGELOG.md
@@ -6,6 +6,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - Production-grade memory-safety pass
+## [2.5.1] - 2026-07-25
+
+### Added
+- **Connection test coverage**: 44 new tests, coverage from 42.8% → ~70%
+- **WebSocket automated tests**: 99 test cases in new test_websocket_automated.cpp
+- **Router test coverage**: find_array_route and match_route_node coverage tests
+- **SDD specification documents**: static-api, tls-api, protocol-upgrade specs
+- **Development rhythm documentation**: AI-driven 24h development workflow
+- **Daily-build CI**: Automatic build and test at UTC 20:00, creates issue on failure
+
+### Changed
+- **uvhttp_server_new_with_loop**: New API for internal event loop management
+- **Documentation**: Removed system libuv dependency from Chinese docs
+- **Documentation style spec**: Added writing standards and AI flavor removal guidelines
+- **VitePress sidebar**: Removed internal dev docs from public website
+
+### Fixed
+- **ASan memory bugs**: 3 fixes for stack-buffer-underflow, null pointer, and test leaks
+- **FAQ API signatures**: Corrected uvhttp_config_new and uvhttp_static_create examples
+- **Product-site consistency**: Removed fabricated data from zh/performance.md
+- **CSP**: Added 'unsafe-inline' for SPA navigation
+
+### Removed
+- **gh-pages branch**: Fully migrated to GitHub Actions deployment
+- **Conflicting skills**: Removed standalone skills in favor of Superpowers framework
+- **Stale branches**: Cleaned up develop, gh-pages, and other unused branches
+- **System libuv dependency**: libuv is now exclusively vendored as submodule
+- **Internal dev docs**: Removed zh/dev/ section from public website sidebar
 
 ### Fixed — genuine memory-safety bugs in library code (all passed normal tests but corrupted memory under ASan)
 

--- a/test/unit/test_connection_boost_coverage.cpp
+++ b/test/unit/test_connection_boost_coverage.cpp
@@ -49,7 +49,9 @@ static void destroy_server_and_loop(uvhttp_server_t* server,
  * After this call the connection pointer is invalid.
  */
 static void close_and_drain(uvhttp_connection_t* conn, uv_loop_t* loop) {
-    uvhttp_connection_close(conn);
+    /* Call free which internally handles close + drain + resource cleanup */
+    uvhttp_connection_free(conn);
+    /* Run the loop to process any pending close callbacks */
     uv_run(loop, UV_RUN_DEFAULT);
 }
 
@@ -65,6 +67,10 @@ TEST(ConnectionBoostCoverage, RestartRead_WithRequestBody) {
     ASSERT_EQ(result, UVHTTP_OK);
 
     ASSERT_NE(conn->request, nullptr);
+    /* Free the body allocated by uvhttp_request_init before replacing it */
+    if (conn->request->body) {
+        uvhttp_free(conn->request->body);
+    }
     conn->request->body = (char*)uvhttp_alloc(128);
     ASSERT_NE(conn->request->body, nullptr);
     conn->request->body_length = 128;
@@ -77,6 +83,7 @@ TEST(ConnectionBoostCoverage, RestartRead_WithRequestBody) {
     EXPECT_EQ(conn->request->body_length, 0u);
     EXPECT_EQ(conn->request->body_capacity, 0u);
 
+    /* The body was already freed by restart_read, no need to free again */
     close_and_drain(conn, loop);
     destroy_server_and_loop(server, loop);
 }
@@ -93,6 +100,10 @@ TEST(ConnectionBoostCoverage, RestartRead_WithResponseBody) {
     ASSERT_EQ(result, UVHTTP_OK);
 
     ASSERT_NE(conn->response, nullptr);
+    /* Free the body allocated by uvhttp_request_init before replacing it */
+    if (conn->response->body) {
+        uvhttp_free(conn->response->body);
+    }
     conn->response->body = (char*)uvhttp_alloc(256);
     ASSERT_NE(conn->response->body, nullptr);
 
@@ -861,6 +872,10 @@ TEST(ConnectionBoostCoverage, RestartRead_ResponseBodyFree) {
     ASSERT_EQ(result, UVHTTP_OK);
 
     ASSERT_NE(conn->response, nullptr);
+    /* Free the body allocated by uvhttp_request_init before replacing it */
+    if (conn->response->body) {
+        uvhttp_free(conn->response->body);
+    }
     conn->response->body = (char*)uvhttp_alloc(512);
     ASSERT_NE(conn->response->body, nullptr);
 


### PR DESCRIPTION
Release v2.5.1\n\n- Connection coverage 42.8% → ~70%\n- WebSocket automated tests (99 cases)\n- 3 new SDD spec documents\n- ASan 93/93 clean\n- Tag: v2.5.1