### PR TITLE
feat: add EN/ZH doc sync detection and CI check

### DIFF
--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -520,6 +520,15 @@ jobs:
     if: always()
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
+
+      - name: Generate doc sync status
+        run: |
+          bash scripts/check-doc-sync.sh
+
       - name: Generate nightly summary
         run: |
           echo "## 🌙 Nightly Test Report" >> $GITHUB_STEP_SUMMARY
@@ -530,6 +539,15 @@ jobs:
           echo "| Coverage | ${{ needs.test-coverage.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Memory Test | ${{ needs.test-memory.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| UBSan Test | ${{ needs.test-ubsan.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Stress Test | ${{ needs.test-stress.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Performance | ${{ needs.performance-full.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Doc Sync Status" >> $GITHUB_STEP_SUMMARY
+          echo "| File | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          for entry in $(python3 -c "import json; d=json.load(open('.vitepress/sync-status.json')); [print(f'{k}|{\"⚠️\" if v[\"outdated\"] else \"✅\"}') for k,v in d.items()]" 2>/dev/null); do
+            echo "| $entry |" >> $GITHUB_STEP_SUMMARY
+          done
           echo "| Stress Test | ${{ needs.test-stress.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Performance | ${{ needs.performance-full.result == 'success' && '✅' || '❌' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -217,10 +217,53 @@ jobs:
         run: |
           echo "format-check target not available in CMake-generated Makefile"
   
+  # 任务: 中英文文档同步检查
+  doc-sync-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
+
+      - name: Check EN/ZH doc sync
+        run: |
+          echo "## 🌐 中英文文档同步检查" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| 文件 | EN 修改时间 | ZH 修改时间 | 状态 |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|-----------|-----------|------|" >> $GITHUB_STEP_SUMMARY
+
+          outdated=0
+          for en_file in $(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep "^docs/.*\.md$" | grep -v "^docs/zh/" | grep -v "/api/" || true); do
+            zh_file="docs/zh/${en_file#docs/}"
+            if [ -f "$zh_file" ]; then
+              en_time=$(git log -1 --format=%ci "$en_file" 2>/dev/null || echo "unknown")
+              zh_time=$(git log -1 --format=%ci "$zh_file" 2>/dev/null || echo "unknown")
+              en_ts=$(git log -1 --format=%ct "$en_file" 2>/dev/null || echo "0")
+              zh_ts=$(git log -1 --format=%ct "$zh_file" 2>/dev/null || echo "0")
+              if [ "$en_ts" -gt "$zh_ts" ]; then
+                echo "| $en_file | $en_time | $zh_time | ⚠️ 可能过时 |" >> $GITHUB_STEP_SUMMARY
+                outdated=$((outdated + 1))
+              else
+                echo "| $en_file | $en_time | $zh_time | ✅ 同步 |" >> $GITHUB_STEP_SUMMARY
+              fi
+            fi
+          done
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "$outdated" -gt 0 ]; then
+            echo "**发现 $outdated 个文件可能过时，请在合并前更新中文翻译。**" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "**所有中文文档与英文同步。** ✅" >> $GITHUB_STEP_SUMMARY
+          fi
+
   # ========== 阶段 2: 生成总结 ==========
-  
+
   generate-summary:
-    needs: [ubuntu-build, code-quality-check, dependency-scan, ubuntu-test-fast, asan-gate, format-check]
+    needs: [ubuntu-build, code-quality-check, dependency-scan, ubuntu-test-fast, asan-gate, format-check, doc-sync-check]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: always()

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -312,5 +312,22 @@ export default defineConfig({
       { icon: 'github', link: 'https://github.com/adam-ikari/uvhttp' },
       { icon: 'twitter', link: 'https://twitter.com/uvhttp_lib' }
     ]
+  },
+  transformHead: ({ page }) => {
+    try {
+      const syncStatus = require('./sync-status.json');
+      if (page && page.relativePath && page.relativePath.startsWith('zh/')) {
+        const enPath = page.relativePath.replace(/^zh\//, '');
+        const entry = syncStatus[enPath];
+        if (entry && entry.outdated) {
+          return [
+            ['meta', { name: 'doc-outdated', content: 'true' }]
+          ];
+        }
+      }
+    } catch (e) {
+      // sync-status.json may not exist in dev mode
+    }
+    return [];
   }
 })

--- a/docs/.vitepress/sync-status.json
+++ b/docs/.vitepress/sync-status.json
@@ -1,0 +1,62 @@
+{
+  "embedded-profile.md": {
+    "en": 1784178077,
+    "zh": 1783967194,
+    "outdated": 1
+  }
+,
+  "guide/build.md": {
+    "en": 1783936101,
+    "zh": 1784002766,
+    "outdated": 0
+  }
+,
+  "guide/CHANGELOG.md": {
+    "en": 1784887445,
+    "zh": 1784178077,
+    "outdated": 1
+  }
+,
+  "guide/getting-started.md": {
+    "en": 1783967194,
+    "zh": 1784848769,
+    "outdated": 0
+  }
+,
+  "guide/introduction.md": {
+    "en": 1784777899,
+    "zh": 1784777899,
+    "outdated": 0
+  }
+,
+  "guide/LINUX_OPTIMIZATION.md": {
+    "en": 1774067240,
+    "zh": 1784002766,
+    "outdated": 0
+  }
+,
+  "guide/MIGRATION_GUIDE_LRU_CACHE.md": {
+    "en": 1774067240,
+    "zh": 1784002766,
+    "outdated": 0
+  }
+,
+  "guide/STATIC_FILE_SERVER.md": {
+    "en": 1784178077,
+    "zh": 1784178077,
+    "outdated": 0
+  }
+,
+  "index.md": {
+    "en": 1784178077,
+    "zh": 1784002766,
+    "outdated": 1
+  }
+,
+  "MEMORY_SAFETY.md": {
+    "en": 1784178077,
+    "zh": 1783967194,
+    "outdated": 1
+  }
+
+}

--- a/scripts/check-doc-sync.sh
+++ b/scripts/check-doc-sync.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Check EN/ZH doc sync status
+# Generates a JSON file with last-modified timestamps for all EN/ZH doc pairs
+# Used by VitePress to show "outdated" warnings on ZH pages
+
+set -euo pipefail
+
+DOCS_DIR="/home/gem/project/uvhttp/docs"
+OUTPUT_FILE="$DOCS_DIR/.vitepress/sync-status.json"
+
+echo "{" > "$OUTPUT_FILE"
+first=true
+
+# Map EN files to ZH files (same relative path under docs/ vs docs/zh/)
+for en_file in $(find "$DOCS_DIR" -name "*.md" -not -path "*/node_modules/*" -not -path "*/.vitepress/*" -not -path "*/zh/*" -not -path "*/api/*" -not -path "*/releases/*" -not -path "*/superpowers/*" -not -path "*/spec/*" | sort); do
+  rel_path="${en_file#$DOCS_DIR/}"
+  zh_file="$DOCS_DIR/zh/$rel_path"
+
+  if [ -f "$zh_file" ]; then
+    en_time=$(git log -1 --format=%ct "$en_file" 2>/dev/null || echo "0")
+    zh_time=$(git log -1 --format=%ct "$zh_file" 2>/dev/null || echo "0")
+
+    if [ "$first" = true ]; then
+      first=false
+    else
+      echo "," >> "$OUTPUT_FILE"
+    fi
+
+    cat >> "$OUTPUT_FILE" << EOF
+  "$rel_path": {
+    "en": $en_time,
+    "zh": $zh_time,
+    "outdated": $(($en_time > $zh_time))
+  }
+EOF
+  fi
+done
+
+echo "" >> "$OUTPUT_FILE"
+echo "}" >> "$OUTPUT_FILE"
+
+echo "Sync status written to $OUTPUT_FILE"
+cat "$OUTPUT_FILE"


### PR DESCRIPTION
Add EN/ZH doc sync detection system:\n\n1. **CI PR check**: When PR modifies EN docs, checks if ZH docs are also updated. Reports in PR summary (warning, not blocking).\n2. **Nightly sync status**: Generates sync-status.json with timestamps.\n3. **VitePress meta tag**: ZH pages with outdated EN versions get 'doc-outdated' meta tag.\n4. **Script**: check-doc-sync.sh for local use.