### PR TITLE
fix: use git hash for doc sync check

### DIFF
--- a/docs/.vitepress/sync-status.json
+++ b/docs/.vitepress/sync-status.json
@@ -1,61 +1,61 @@
 {
   "embedded-profile.md": {
-    "en": 1784178077,
-    "zh": 1783967194,
+    "en": "5a26c78ba54717d041c4fde52fcf1efa0586cc9c",
+    "zh": "bec4872c7a030bbfa520ce16ded89a9b6df61bbe",
     "outdated": 1
   }
 ,
   "guide/build.md": {
-    "en": 1783936101,
-    "zh": 1784002766,
-    "outdated": 0
+    "en": "a47bc5a32186776500458a086ff0baacfd5163af",
+    "zh": "2fe6681e722d0a3c8aa82af4e1ea482f8e79de7a",
+    "outdated": 1
   }
 ,
   "guide/CHANGELOG.md": {
-    "en": 1784887445,
-    "zh": 1784178077,
+    "en": "89f33b9d2353b11a66db73a33312cd851292d310",
+    "zh": "5a26c78ba54717d041c4fde52fcf1efa0586cc9c",
     "outdated": 1
   }
 ,
   "guide/getting-started.md": {
-    "en": 1783967194,
-    "zh": 1784848769,
-    "outdated": 0
+    "en": "bec4872c7a030bbfa520ce16ded89a9b6df61bbe",
+    "zh": "d7fb5034212b78cdfb31c77546796e486a844d62",
+    "outdated": 1
   }
 ,
   "guide/introduction.md": {
-    "en": 1784777899,
-    "zh": 1784777899,
+    "en": "4582a5a23dbdba1621fdb667c665ba2fde61b1e2",
+    "zh": "4582a5a23dbdba1621fdb667c665ba2fde61b1e2",
     "outdated": 0
   }
 ,
   "guide/LINUX_OPTIMIZATION.md": {
-    "en": 1774067240,
-    "zh": 1784002766,
-    "outdated": 0
+    "en": "24b63df81b6c3e86daaa9e108437255121d026f6",
+    "zh": "2fe6681e722d0a3c8aa82af4e1ea482f8e79de7a",
+    "outdated": 1
   }
 ,
   "guide/MIGRATION_GUIDE_LRU_CACHE.md": {
-    "en": 1774067240,
-    "zh": 1784002766,
-    "outdated": 0
+    "en": "24b63df81b6c3e86daaa9e108437255121d026f6",
+    "zh": "2fe6681e722d0a3c8aa82af4e1ea482f8e79de7a",
+    "outdated": 1
   }
 ,
   "guide/STATIC_FILE_SERVER.md": {
-    "en": 1784178077,
-    "zh": 1784178077,
+    "en": "5a26c78ba54717d041c4fde52fcf1efa0586cc9c",
+    "zh": "5a26c78ba54717d041c4fde52fcf1efa0586cc9c",
     "outdated": 0
   }
 ,
   "index.md": {
-    "en": 1784178077,
-    "zh": 1784002766,
+    "en": "5a26c78ba54717d041c4fde52fcf1efa0586cc9c",
+    "zh": "2fe6681e722d0a3c8aa82af4e1ea482f8e79de7a",
     "outdated": 1
   }
 ,
   "MEMORY_SAFETY.md": {
-    "en": 1784178077,
-    "zh": 1783967194,
+    "en": "5a26c78ba54717d041c4fde52fcf1efa0586cc9c",
+    "zh": "bec4872c7a030bbfa520ce16ded89a9b6df61bbe",
     "outdated": 1
   }
 

--- a/scripts/check-doc-sync.sh
+++ b/scripts/check-doc-sync.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # Check EN/ZH doc sync status
-# Generates a JSON file with last-modified timestamps for all EN/ZH doc pairs
-# Used by VitePress to show "outdated" warnings on ZH pages
+# Compares git hashes of EN and ZH doc pairs.
+# If the EN file has a different hash than the ZH file (meaning EN was
+# updated without updating ZH), marks it as outdated.
+#
+# Usage: bash scripts/check-doc-sync.sh
+# Output: docs/.vitepress/sync-status.json
 
 set -euo pipefail
 
@@ -11,14 +15,13 @@ OUTPUT_FILE="$DOCS_DIR/.vitepress/sync-status.json"
 echo "{" > "$OUTPUT_FILE"
 first=true
 
-# Map EN files to ZH files (same relative path under docs/ vs docs/zh/)
 for en_file in $(find "$DOCS_DIR" -name "*.md" -not -path "*/node_modules/*" -not -path "*/.vitepress/*" -not -path "*/zh/*" -not -path "*/api/*" -not -path "*/releases/*" -not -path "*/superpowers/*" -not -path "*/spec/*" | sort); do
   rel_path="${en_file#$DOCS_DIR/}"
   zh_file="$DOCS_DIR/zh/$rel_path"
 
   if [ -f "$zh_file" ]; then
-    en_time=$(git log -1 --format=%ct "$en_file" 2>/dev/null || echo "0")
-    zh_time=$(git log -1 --format=%ct "$zh_file" 2>/dev/null || echo "0")
+    en_hash=$(git log -1 --format=%H "$en_file" 2>/dev/null || echo "0000")
+    zh_hash=$(git log -1 --format=%H "$zh_file" 2>/dev/null || echo "0000")
 
     if [ "$first" = true ]; then
       first=false
@@ -28,9 +31,9 @@ for en_file in $(find "$DOCS_DIR" -name "*.md" -not -path "*/node_modules/*" -no
 
     cat >> "$OUTPUT_FILE" << EOF
   "$rel_path": {
-    "en": $en_time,
-    "zh": $zh_time,
-    "outdated": $(($en_time > $zh_time))
+    "en": "$en_hash",
+    "zh": "$zh_hash",
+    "outdated": $([ "$en_hash" != "$zh_hash" ] && echo "1" || echo "0")
   }
 EOF
   fi
@@ -38,6 +41,3 @@ done
 
 echo "" >> "$OUTPUT_FILE"
 echo "}" >> "$OUTPUT_FILE"
-
-echo "Sync status written to $OUTPUT_FILE"
-cat "$OUTPUT_FILE"


### PR DESCRIPTION
Replace timestamp comparison with git hash comparison for EN/ZH doc sync detection. Git hashes only change when content changes.