### PR TITLE
docs: add sync_hash to all ZH translation files

### DIFF
--- a/docs/zh/MEMORY_SAFETY.md
+++ b/docs/zh/MEMORY_SAFETY.md
@@ -1,5 +1,6 @@
 ---
 title: 内存安全 — ASan 与 UBSan 验证
+sync_hash: 5a26c78ba54717d041c4fde52fcf1efa0586cc9c
 description: UVHTTP 的内存安全保证：91 项测试通过 ASan 与 UBSan 验证，每夜 CI 持续验证，一键复现。涵盖已修复的 bug 类别、纵深防御，以及对长期运行与嵌入式场景的意义。
 ---
 

--- a/docs/zh/embedded-profile.md
+++ b/docs/zh/embedded-profile.md
@@ -1,5 +1,6 @@
 ---
 title: 嵌入式与长期运行画像
+sync_hash: 5a26c78ba54717d041c4fde52fcf1efa0586cc9c
 description: UVHTTP 嵌入式与长跑指标：持续负载下 RSS 持平（60s 零增长）、静态库 ~257 KB、冷启动 ~310ms、支持 32 位。ASan-clean 内存安全保证的运行时佐证。
 ---
 

--- a/docs/zh/guide/CHANGELOG.md
+++ b/docs/zh/guide/CHANGELOG.md
@@ -1,5 +1,6 @@
 ---
 title: 更新日志
+sync_hash: 89f33b9d2353b11a66db73a33312cd851292d310
 description: UVHTTP 全部重要变更记录。格式基于 Keep a Changelog，遵循语义化版本规范。涵盖 1.0.0 至 2.5.0 各版本的新增、修复、变更、安全与性能改进，以及生产级内存安全验证。
 ---
 

--- a/docs/zh/guide/LINUX_OPTIMIZATION.md
+++ b/docs/zh/guide/LINUX_OPTIMIZATION.md
@@ -1,3 +1,7 @@
+---
+sync_hash: 24b63df81b6c3e86daaa9e108437255121d026f6
+title: UVHTTP Linux 优化指南
+---
 # UVHTTP Linux 优化指南
 
 ## Linux 专属优化

--- a/docs/zh/guide/MIGRATION_GUIDE_LRU_CACHE.md
+++ b/docs/zh/guide/MIGRATION_GUIDE_LRU_CACHE.md
@@ -1,3 +1,7 @@
+---
+sync_hash: 24b63df81b6c3e86daaa9e108437255121d026f6
+title: LRU 缓存迁移指南
+---
 # LRU 缓存迁移指南
 
 ## 概述

--- a/docs/zh/guide/STATIC_FILE_SERVER.md
+++ b/docs/zh/guide/STATIC_FILE_SERVER.md
@@ -1,3 +1,7 @@
+---
+sync_hash: 5a26c78ba54717d041c4fde52fcf1efa0586cc9c
+title: UVHTTP 静态文件服务器指南
+---
 # UVHTTP 静态文件服务器指南
 
 ## 概述

--- a/docs/zh/guide/build.md
+++ b/docs/zh/guide/build.md
@@ -1,5 +1,6 @@
 ---
 title: 构建指南
+sync_hash: a47bc5a32186776500458a086ff0baacfd5163af
 description: "UVHTTP 构建指南——从源码编译、构建选项、交叉编译到故障排除，涵盖 CMake 配置、性能测试与安装路径。"
 ---
 

--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -1,5 +1,6 @@
 ---
 title: 快速开始
+sync_hash: bec4872c7a030bbfa520ce16ded89a9b6df61bbe
 description: 几分钟上手 UVHTTP——构建 C99 HTTP/WebSocket 服务器库，运行 hello-world 示例，添加第一条路由。涵盖 CMake/Just 构建、示例服务器与首个请求。
 ---
 

--- a/docs/zh/guide/introduction.md
+++ b/docs/zh/guide/introduction.md
@@ -1,5 +1,6 @@
 ---
 title: 简介
+sync_hash: 4582a5a23dbdba1621fdb667c665ba2fde61b1e2
 description: UVHTTP 是基于 libuv 的 HTTP/1.1 与 WebSocket 服务器库，C99 编写。ASan/UBSan 验证内存安全，支持 32 位嵌入式，零拷贝，模块化特性。
 ---
 

--- a/docs/zh/performance.md
+++ b/docs/zh/performance.md
@@ -1,5 +1,6 @@
 ---
 title: 性能基准
+sync_hash: bec4872c7a030bbfa520ce16ded89a9b6df61bbe
 description: UVHTTP 性能基准——~20K RPS、100 至 500 连接吞吐持平、零 socket 错误、P50/P99 延迟。在 AMD Ryzen 7 5800H 上用 wrk 测得，含复现命令与历史基准。
 ---
 


### PR DESCRIPTION
Add sync_hash field to all Chinese documentation frontmatter, recording the English source file's git hash. Enables automated sync detection.