### PR TITLE
fix: deploy-docs.yml uses wrong npm script name

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -55,7 +55,7 @@ jobs:
           npm run api:generate
           
           # Build VitePress documentation site
-          DEPLOY=pages npm run build
+          DEPLOY=pages npm run docs:build
           
           # Add .nojekyll file to disable Jekyll processing on GitHub Pages
           # This is critical for VitePress client-side routing to work correctly

--- a/docs/index.md
+++ b/docs/index.md
@@ -163,3 +163,4 @@ For detailed installation instructions and build options, see the [Installation 
 - **[Installation Guide](/guide/INSTALL_CMAKE)** - Installation and build guide
 - **[Performance Guide](/guide/performance)** - Performance optimization tips
 - **[FAQ](/guide/FAQ)** - Frequently asked questions
+<!-- site updated: 1784942602 -->


### PR DESCRIPTION
CI runs 'npm run build' but package.json only has 'docs:build'. This caused all recent deployments to fail silently.