### PR TITLE
docs: fix development rhythm document issues

### DIFF
--- a/docs/development-rhythm.md
+++ b/docs/development-rhythm.md
@@ -2,7 +2,7 @@
 
 ## 每周周期
 
-AI 持续开发，24h 不间断。每周 5 个 Sprint 开发，周末 2 天作为 buffer 支配。
+AI 持续开发，24h 不间断。每周 5 个 Sprint 开发，周末按需。
 
 | 天 | Sprint | 活动 | 产出 |
 |---|--------|------|------|
@@ -10,15 +10,16 @@ AI 持续开发，24h 不间断。每周 5 个 Sprint 开发，周末 2 天作�
 | 周二 | Sprint 2 | 开发 | 15-25 个 PR |
 | 周三 | Sprint 3 | 开发 | 15-25 个 PR |
 | 周四 | Sprint 4 | 开发 | 15-25 个 PR |
-| 周五 | Sprint 5 | 测试 + 发布 | v2.x.y |
-| 周六 | — | 按需 | 视 backlog 情况 |
-| 周日 | — | 按需 | 视 backlog 情况 |
+| 周五 | Sprint 5 | 测试 + 发布 | 版本发布 |
+| 周六/周日 | — | 按需 | 仅溢出任务或紧急 bug |
+
+Sprint 编号仅用于标识开发周期，不与版本号绑定。版本号由变更内容决定（patch/minor/major）。
 
 ## 每日节奏
 
-1. **确认日期**: 运行 `date "+%Y-%m-%d %A"` 确认今天是周几，判断当前 Sprint 阶段
-2. **检查 daily-build 结果**: 如果有失败，创建 bug issue 加入当日 backlog
-3. **从 Product Backlog 选取最高优先级任务**
+1. **确认日期**: `date "+%Y-%m-%d %A"` 确定周几，判断 Sprint 阶段
+2. **检查 daily-build 结果**: 查看 CI 日志，有失败则创建 Issue
+3. **从 GitHub Issues 选取最高优先级任务**（以 Issues 为准，sprint-backlog.md 为概览参考）
 4. **并行派发 subagent 执行**
 5. **持续开发直到当日 Sprint 完成**
 
@@ -26,14 +27,22 @@ AI 持续开发，24h 不间断。每周 5 个 Sprint 开发，周末 2 天作�
 
 | 天 | Sprint | 确认要点 |
 |---|--------|---------|
-| 周一至周四 | Sprint 1-4 | 开发，选取 Product Backlog 中优先级最高的任务 |
+| 周一至周四 | Sprint 1-4 | 开发，从 GitHub Issues 选取 P0/P1 任务 |
 | 周五 | Sprint 5 | 代码冻结，只做测试+发布，不引入新代码 |
-| 周末 | — | 按需，根据 backlog 和工作量决定 |
-| 周六/周日 | — | 按需，根据 backlog 和工作量决定 |
+| 周末 | — | 判断是否有溢出任务或紧急 bug，否则休息 |
 
-## 当前日期映射
+## 周末判断标准
 
-运行 `date "+%Y-%m-%d %A"` 确定当天活动。
+周末是否开发：
+- **有 Sprint 溢出任务** → 继续开发
+- **有紧急 bug（P0）** → 修复
+- **以上都没有** → 不开发
+
+## 任务管理
+
+- **GitHub Issues** 是唯一任务来源，带 `sprint-N` label
+- **docs/sprint-backlog.md** 只作为概览参考，不单独维护
+- 每天从 Issues 中选取 `sprint-N` + `P1` 优先级最高的任务
 
 ## Sprint 容量
 
@@ -49,7 +58,7 @@ AI 持续开发，24h 不间断。每周 5 个 Sprint 开发，周末 2 天作�
 
 ## 自动化
 
-- **daily-build** (每日凌晨): 构建 + 测试，失败自动创建 Issue
+- **daily-build** (每日凌晨): 构建 + 测试，失败记录在 CI 日志中
 - **nightly** (每日): 深度测试 + 覆盖率 + ASan + UBSan
 - **PR CI**: 每次 PR 自动验证
 - **deploy**: 合并 main 自动部署网站


### PR DESCRIPTION
Fix 5 issues:\n1. Sprint numbers not tied to version numbers\n2. Weekend development conditional\n3. GitHub Issues is single source of truth\n4. sprint-backlog.md is reference only\n5. No retro ceremony needed